### PR TITLE
Remove deprecated `has_rdoc`, refresh some RDoc options in gemspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .svn
 pkg
-doc
+/doc
+/html
 *.swp
 .DS_Store
 spec/rubycas-client.sqlite3.db

--- a/rubycas-client.gemspec
+++ b/rubycas-client.gemspec
@@ -7,12 +7,11 @@ Gem::Specification.new do |s|
   s.date = %q{2008-11-18}
   s.description = %q{Client library for the Central Authentication Service (CAS) protocol.}
   s.email = %q{matt at roughest dot net}
-  s.extra_rdoc_files = ["CHANGELOG.txt", "History.txt", "LICENSE.txt", "Manifest.txt", "README.rdoc"]
-  s.files = ["CHANGELOG.txt", "History.txt", "LICENSE.txt", "Manifest.txt", "README.rdoc", "Rakefile", "init.rb", "lib/casclient.rb", "lib/casclient/client.rb",
+  s.extra_rdoc_files = ["CHANGELOG.txt", "History.txt", "LICENSE.txt", "Manifest.txt", "README.md"]
+  s.files = ["CHANGELOG.txt", "History.txt", "LICENSE.txt", "Manifest.txt", "README.md", "Rakefile", "init.rb", "lib/casclient.rb", "lib/casclient/client.rb",
   "lib/casclient/frameworks/rails/cas_proxy_callback_controller.rb", "lib/casclient/frameworks/rails/request_handler.rb", "lib/casclient/frameworks/rails/filter.rb", "lib/casclient/responses.rb", "lib/casclient/tickets.rb", "lib/casclient/version.rb", "lib/rubycas-client.rb", "setup.rb"]
-  s.has_rdoc = true
   s.homepage = %q{http://rubycas-client.rubyforge.org}
-  s.rdoc_options = ["--main", "README.txt"]
+  s.rdoc_options = ["--main", "README.md"]
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{rubycas-client}
   s.rubygems_version = %q{1.2.0}


### PR DESCRIPTION
This is just to remove the annoying deprecation shown every time we do a bundle:
```
[...]
Fetching https://github.com/konvenit/rubycas-client.git
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed in Rubygems 4
Gem::Specification#has_rdoc= called from /usr/local/bundle/bundler/gems/rubycas-client-71f66718231a..
                                         ../rubycas-client.gemspec:13.
[...]
```

Updating `README.{rdoc,txt} -> README.md` in the gemspec was just a tiny cleaning thingy.

At least when I run `rdoc --main README.md` (because this option is specified in the gemspec) it does create _some_ documentation in the `./doc` folder, and the main page is really this README.